### PR TITLE
Build with OpenSSL 1 and 3 [skip ci]

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,3 @@
 # the conda-build parameters to use for disabling --skip-existing
 build_parameters:
   - ""
-
-channels:
-  staging_openssl3: openssl3
-
-aggregate_branch: openssl3_builds
-aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,8 @@
 build_parameters:
   - ""
 
+channels:
+  staging_openssl3: openssl3
+
+aggregate_branch: openssl3_builds
+aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,8 @@
 # the conda-build parameters to use for disabling --skip-existing
 build_parameters:
   - ""
+
+channels:
+  jcmorin-ana-org: qt
+
+upload_without_merge: true

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -95,7 +95,6 @@ call "../configure" ^
      -system-sqlite ^
      -system-zlib ^
      -plugin-sql-sqlite ^
-     -plugin-sql-mysql ^
      -plugin-sql-psql ^
      -qtlibinfix %QT_LIBINFIX% ^
      -verbose

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -95,6 +95,8 @@ call "../configure" ^
      -system-sqlite ^
      -system-zlib ^
      -plugin-sql-sqlite ^
+     -plugin-sql-mysql ^
+     -plugin-sql-psql ^
      -qtlibinfix %QT_LIBINFIX% ^
      -verbose
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -84,8 +84,7 @@ call "../configure" ^
      -skip qtwebengine ^
      -opengl %OPENGLVER% ^
      -opensource ^
-     -openssl ^
-     -openssl-runtime ^
+     -openssl-linked ^
      -platform win32-msvc ^
      -release ^
      -shared ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -141,7 +141,6 @@ if [[ $(uname) == "Linux" ]]; then
                 ${REDUCE_RELOCATIONS} \
                 -cups \
                 -openssl-linked \
-                -openssl \
                 -Wno-expansion-to-defined \
                 -D _X_INLINE=inline \
                 -D XK_dead_currency=0xfe6f \
@@ -238,6 +237,7 @@ if [[ ${HOST} =~ .*darwin.* ]]; then
                 -system-zlib \
                 -system-sqlite \
                 -plugin-sql-sqlite \
+                -plugin-sql-mysql \
                 -plugin-sql-psql \
                 -qt-freetype \
                 -qt-pcre \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -247,7 +247,7 @@ if [[ ${HOST} =~ .*darwin.* ]]; then
                 -no-harfbuzz \
                 -no-libudev \
                 -no-egl \
-                -no-openssl \
+                -openssl-linked \
                 -optimize-size
 
 # For quicker turnaround when e.g. checking compilers optimizations

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -167,7 +167,7 @@ requirements:
     - openssl  # exact pin handled through openssl run_exports
     - mysql 5.7.*  # [unix]
     - sqlite
-    - libcups 2.*
+    - libcups 2.*  # [linux]
     - krb5  # exact pin handled through krb5 run_exports
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.14") }}  # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -154,7 +154,7 @@ requirements:
     - postgresql 12.15.0                 # [not win]
     - zlib
     - libxcb                             # [linux]
-    - openssl {{ openssl }}              # [linux]
+    - openssl {{ openssl }}
     # For QDoc
     # http://doc.qt.io/Qt-5/qdoc-guide-clang.html
     # Only libclang is needed, but needs the full package for detection.
@@ -167,7 +167,7 @@ requirements:
   run:
     - libxcb                             # [linux]
     - {{ pin_compatible("libclang") }}
-    - openssl 3.*                        # [linux]
+    - openssl  # exact pin handled through openssl run_exports
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.14") }}  # [osx and x86_64]
     - qt >=5.15.2,<6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,8 @@ build:
     - /usr/lib/libresolv.9.dylib  # [osx]
     - /usr/lib/libsandbox.1.dylib  # [osx]
     - '/System/Library/Frameworks/CoreLocation.framework/**'  # [osx]
+    - $RPATH/api-ms-win-core-winrt-l1-1-0.dll
+    - $RPATH/api-ms-win-core-winrt-string-l1-1-0.dll
 
 requirements:
   build:
@@ -135,9 +137,9 @@ requirements:
     - dbus                               # [linux]
     - fontconfig                         # [linux]
     - freetype                           # [linux]
-    - glib
-    - gst-plugins-base
-    - gstreamer
+    - glib              # [not win]
+    - gst-plugins-base  # [not win]
+    - gstreamer         # [not win]
     - pulseaudio                         # [linux and not (aarch64 or x86_64)]
     - libxkbcommon                       # [linux]
     - icu

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,8 +51,8 @@ build:
     - /usr/lib/libresolv.9.dylib  # [osx]
     - /usr/lib/libsandbox.1.dylib  # [osx]
     - '/System/Library/Frameworks/CoreLocation.framework/**'  # [osx]
-    - $RPATH/api-ms-win-core-winrt-l1-1-0.dll
-    - $RPATH/api-ms-win-core-winrt-string-l1-1-0.dll
+    - '*/api-ms-win-core-winrt-l1-1-0.dll'  # [win]
+    - '*/api-ms-win-core-winrt-string-l1-1-0.dll'  # [win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ source:
     sha256: 4a9dc893cc0a1695a16102a42ef47ef2e228652891f4afea67fadd452b63656b  # [win]
 
 build:
-  number: 8
+  number: 9
   version: {{ version }}
   detect_binary_files_with_prefix: true
   skip: true   # [ppc64le or s390x]
@@ -113,7 +113,6 @@ requirements:
     - pkg-config                         # [unix]
     - make                               # [unix]
     - ninja
-    - ruby >=2.5                         # [linux]
     - bison                              # [linux]
     - flex                               # [linux]
     - gperf                              # [linux]
@@ -143,38 +142,32 @@ requirements:
     - libxml2 2.10                       # [linux]
     - libxkbcommon                       # [linux]
     - expat                              # [linux]
-    - libevent                           # [linux]
+    - libevent 2.1.12                    # [linux]
     - icu
     # jpeg-turbo currently has some conflicting issues in conda-forge
     # see: https://github.com/conda-forge/conda-forge.github.io/issues/673
     - jpeg
     - libpng
-    - nspr                               # [unix]
-    - nss                                # [unix]
     - sqlite
     # - mysql-devel                        # [not win]
     - mysql                              # [linux]
-    - postgresql                         # [not win]
+    - postgresql 12.15.0                 # [not win]
     - zlib
     - libxcb                             # [linux]
-    - openssl
+    - openssl {{ openssl }}              # [linux]
     # For QDoc
     # http://doc.qt.io/Qt-5/qdoc-guide-clang.html
     # Only libclang is needed, but needs the full package for detection.
     - llvmdev
     - clangdev
     - libclang
-    - libcups                            # [linux]
+    - libcups 2.4.2                      # [linux]
     - zstd
     - alsa-lib                           # [linux and not (aarch64 or x86_64)]
-    - krb5
   run:
-    - {{ pin_compatible("nss") }}        # [unix]
-    - {{ pin_compatible("nspr") }}       # [unix]
     - libxcb                             # [linux]
     - {{ pin_compatible("libclang") }}
-    - openssl
-    - krb5
+    - openssl 3.*                        # [linux]
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.14") }}  # [osx and x86_64]
     - qt >=5.15.2,<6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -139,22 +139,19 @@ requirements:
     - gst-plugins-base
     - gstreamer
     - pulseaudio                         # [linux and not (aarch64 or x86_64)]
-    - libxml2 2.10                       # [linux]
     - libxkbcommon                       # [linux]
-    - expat                              # [linux]
-    - libevent 2.1.12                    # [linux]
     - icu
     # jpeg-turbo currently has some conflicting issues in conda-forge
     # see: https://github.com/conda-forge/conda-forge.github.io/issues/673
     - jpeg
     - libpng
     - sqlite
-    # - mysql-devel                        # [not win]
-    - mysql                              # [linux]
-    - postgresql 12.15.0                 # [not win]
+    - mysql 5.7.24
+    - postgresql 12.15
     - zlib
     - libxcb                             # [linux]
     - openssl {{ openssl }}
+    - krb5 1.20.1
     # For QDoc
     # http://doc.qt.io/Qt-5/qdoc-guide-clang.html
     # Only libclang is needed, but needs the full package for detection.
@@ -168,6 +165,10 @@ requirements:
     - libxcb                             # [linux]
     - {{ pin_compatible("libclang") }}
     - openssl  # exact pin handled through openssl run_exports
+    - mysql 5.7.*
+    - sqlite
+    - libcups 2.*
+    - krb5  # exact pin handled through krb5 run_exports
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.14") }}  # [osx and x86_64]
     - qt >=5.15.2,<6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,8 +51,8 @@ build:
     - /usr/lib/libresolv.9.dylib  # [osx]
     - /usr/lib/libsandbox.1.dylib  # [osx]
     - '/System/Library/Frameworks/CoreLocation.framework/**'  # [osx]
-    - '*/api-ms-win-core-winrt-l1-1-0.dll'  # [win]
-    - '*/api-ms-win-core-winrt-string-l1-1-0.dll'  # [win]
+    #- '*/api-ms-win-core-winrt-l1-1-0.dll'  # [win]
+    #- '*/api-ms-win-core-winrt-string-l1-1-0.dll'  # [win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -146,7 +146,7 @@ requirements:
     - jpeg
     - libpng
     - sqlite
-    - mysql 5.7.24
+    - mysql 5.7.24  # [unix]
     - postgresql 12.15
     - zlib
     - libxcb                             # [linux]
@@ -165,7 +165,7 @@ requirements:
     - libxcb                             # [linux]
     - {{ pin_compatible("libclang") }}
     - openssl  # exact pin handled through openssl run_exports
-    - mysql 5.7.*
+    - mysql 5.7.*  # [unix]
     - sqlite
     - libcups 2.*
     - krb5  # exact pin handled through krb5 run_exports


### PR DESCRIPTION
Build with OpenSSL 1 and 3.

Changes:
* Made sure that openssl is dynamically linked to the Qt libraries on all platforms. It wasn't the case on Windows and macOS.
* Add support for the PostgreSQL plugin on Windows to be consistent with Linux and macOS.
* Add support for the MySQL plugin no macOS to be consistent with Linux. We don't have mysql on Windows, so that's why that plugin isn't compiled on Windows.
* A little cleanup of the dependencies to remove some DSO warnings.

Additional notes:
* I intend to add `[skip-ci]` in the PR title just before merging to avoid having to re-build during the merge. I will manually download the artifacts on zeus and I'll do the release with scotty, as usual. This is because these builds are really long.