### PR TITLE
work around gl integration issues on recent linux distros

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# explanation in build.sh
+
+export CONDA_BACKUP_QT_XCB_GL_INTEGRATION=$QT_XCB_GL_INTEGRATION
+export QT_XCB_GL_INTEGRATION=none

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -303,3 +303,18 @@ for f in $(find * -iname "*LICENSE*" -or -iname "*COPYING*" -or -iname "*COPYRIG
   rm -rf "$LICENSE_DIR/qtwebengine/src/3rdparty/chromium/third_party/skia/tools/copyright"
 done
 
+# qt-main is currently built with gcc 11 and uses cdts to set dependencies on opengl.
+# On host systems with a recent opengl, qt-main loads the system's libgallium while loading opengl.
+# Recent libgallium depend on GLIBCXX_3.4.30. libstdc++.so.6 from gcc 11 only supports up to GLIBCXX_3.4.29.
+# This causes qt applications relying on opengl integration to crash.
+# Long term solutions are to rebuild this package with a more recent GCC, and/or provide opengl as a conda package.
+# For the time being, we are adding activation scripts to temporarily disable opengl integration.
+if [[ $(uname) == "Linux" ]]; then
+  # Copy the [de]activate scripts to $PREFIX/etc/conda/[de]activate.d.
+  # This will allow them to be run on environment activation.
+  for CHANGE in "activate" "deactivate"
+  do
+      mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
+      cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
+  done
+fi

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# explanation in build.sh
+
+if [ "$CONDA_BACKUP_QT_XCB_GL_INTEGRATION" ];
+then
+    export QT_XCB_GL_INTEGRATION="$CONDA_BACKUP_QT_XCB_GL_INTEGRATION"
+else
+    unset QT_XCB_GL_INTEGRATION
+fi
+unset CONDA_BACKUP_QT_XCB_GL_INTEGRATION

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ source:
     sha256: 4a9dc893cc0a1695a16102a42ef47ef2e228652891f4afea67fadd452b63656b  # [win]
 
 build:
-  number: 11
+  number: 12
   version: {{ version }}
   detect_binary_files_with_prefix: true
   skip: true   # [ppc64le or s390x]


### PR DESCRIPTION
qt-main is currently built with gcc 11 and uses cdts to set dependencies on opengl.
On host systems with a recent opengl, qt-main loads the system's libgallium while loading opengl.
Recent libgallium depend on GLIBCXX_3.4.30. libstdc++.so.6 from gcc 11 only supports up to GLIBCXX_3.4.29.
This causes qt applications relying on opengl integration to crash.
Long term solutions are to rebuild this package with a more recent GCC, and/or provide opengl as a conda package.
For the time being, we are adding activation scripts to temporarily disable opengl integration.
