### PR TITLE
Rebuild against libxml2

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,15 @@
 @echo on
-pushd qt
 
+subst Y: "%SRC_DIR%"
+subst X: "%PREFIX%"
+set SRC_DIR=Y:
+set PREFIX=X:
+set LIBRARY_PREFIX=X:\Library
+set LIBRARY_BIN=X:\Library\bin
+set LIBRARY_LIB=X:\Library\lib
+set LIBRARY_INC=X:\Library\include
+
+pushd Y:\qt
 set NINJAFLAGS="-j3"
 
 setlocal EnableExtensions EnableDelayedExpansion
@@ -131,3 +140,6 @@ popd
 if not exist %PREFIX%\Scripts mkdir %PREFIX%\Scripts
 copy "%RECIPE_DIR%\write_qtconf.bat" "%PREFIX%\Scripts\.qt-post-link.bat"
 if %errorlevel% neq 0 exit /b %errorlevel%
+
+subst Y: /d
+subst X: /d

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -141,5 +141,6 @@ if not exist %PREFIX%\Scripts mkdir %PREFIX%\Scripts
 copy "%RECIPE_DIR%\write_qtconf.bat" "%PREFIX%\Scripts\.qt-post-link.bat"
 if %errorlevel% neq 0 exit /b %errorlevel%
 
+popd
 subst Y: /d
 subst X: /d

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,6 @@
 @echo on
 
+:: Workaround for long path issues
 subst Y: "%SRC_DIR%"
 subst X: "%PREFIX%"
 set SRC_DIR=Y:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -107,7 +107,7 @@ requirements:
     - msys2-gperf                        # [win]
     - msys2-bison                        # [win]
     - msys2-flex                         # [win]
-    - jom                                # [win]
+    - jom  1.1.2                         # [win]
     - curl                               # [win]
     - perl 5.*
     # Add readline here, so that newest readline is used.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,7 +80,7 @@ source:
     sha256: 4a9dc893cc0a1695a16102a42ef47ef2e228652891f4afea67fadd452b63656b  # [win]
 
 build:
-  number: 13
+  number: 14
   version: {{ version }}
   detect_binary_files_with_prefix: true
   run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,10 +52,9 @@ source:
 
       # https://github.com/conda-forge/qt-main-feedstock/pull/282#issuecomment-2349349013
       # icu 75 requires C++17, so enable it also in the dummy compilation of a icu snippet that qmake does for configuration
-      #- patches/qt/0019-use-cxx17-for-icu-config-tests.patch
+      - patches/qt/0019-use-cxx17-for-icu-config-tests.patch
       # similarly, mapbox-gl-native uses icu, so we need to make sure that it compiles with C++17
-      #- patches/qt/0020-compile-mapbox-gl-native-with-cxx17-for-icu75-compat.patch
-      # commented as Anaconda is using icu 73.1
+      - patches/qt/0020-compile-mapbox-gl-native-with-cxx17-for-icu75-compat.patch
 
       # mapbox-gl-native uses a old vendored boost, make sure that we used an up-to-date boost instead
       - patches/qt/0021-unvendor-boost-from-mapbox-gl-native.patch


### PR DESCRIPTION
qt-main 5.15.2

**Destination channel:**  defaults

### Links

- [PKG-14746](https://anaconda.atlassian.net/browse/PKG-14746) 
- [Upstream repository](https://github.com/qt)

### Explanation of changes:
- Rebuild with newer version of dependencies


[PKG-14746]: https://anaconda.atlassian.net/browse/PKG-14746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ